### PR TITLE
E0-S2: Implement spike.py polling loop (#3)

### DIFF
--- a/meteoedge-spike/envelope.py
+++ b/meteoedge-spike/envelope.py
@@ -1,6 +1,9 @@
+"""Envelope and edge calculations. This is the heart of the strategy."""
 from dataclasses import dataclass
 from datetime import datetime
+from math import erf, sqrt
 from config import DEFAULT_CLIMB_LOOKUP, FORECAST_STDDEV_F
+
 
 @dataclass
 class WeatherState:
@@ -13,18 +16,70 @@ class WeatherState:
     latest_temp_time: datetime
     forecast_high_f: float | None
 
+
 @dataclass
 class Bracket:
     ticker: str
-    low_f: float
-    high_f: float
+    low_f: float   # inclusive lower bound
+    high_f: float  # inclusive upper bound
     yes_ask_cents: int
     yes_ask_size: int
     no_ask_cents: int
     no_ask_size: int
 
+
+def p_normal_between(low: float, high: float, mean: float, stddev: float) -> float:
+    """P(low <= X <= high) for X ~ N(mean, stddev^2)."""
+    def cdf(x): return 0.5 * (1 + erf((x - mean) / (stddev * sqrt(2))))
+    return max(0.0, min(1.0, cdf(high) - cdf(low)))
+
+
+def expected_additional_rise(station: str, now_local: datetime) -> float:
+    """Look up the p95 additional daily high rise possible from `now` to end of day."""
+    hour = now_local.hour
+    # Temps functionally cannot rise after sunset for daily-high purposes
+    if hour >= 20:
+        return 0.0
+    return DEFAULT_CLIMB_LOOKUP.get(hour, 0.0)
+
+
 def compute_envelope(state: WeatherState) -> tuple[float, float]:
-    return (0.0, 0.0)
+    """Return (min_plausible_high, max_plausible_high) for the rest of the day."""
+    min_high = state.current_high_f
+    additional = expected_additional_rise(state.station, state.now_local)
+    # Peak-from-here plus p95 rise gives the upper envelope
+    max_high = max(
+        state.current_high_f,
+        state.latest_temp_f + additional,
+    )
+    return min_high, max_high
+
 
 def true_probability_yes(bracket: Bracket, state: WeatherState) -> float:
-    return 0.0
+    """
+    Compute P(daily high falls in this bracket).
+    Returns values in [0, 1].
+    """
+    lo, hi = bracket.low_f, bracket.high_f
+    min_env, max_env = compute_envelope(state)
+
+    # Bracket entirely below current daily high: impossible as the *daily high*
+    # (the high already exceeded this range)
+    if hi < state.current_high_f:
+        return 0.0
+
+    # Bracket entirely above max envelope: impossible
+    if lo > max_env:
+        return 0.0
+
+    # Bracket fully contains current high and max envelope is within it: certain
+    if lo <= state.current_high_f and hi >= max_env:
+        return 1.0
+
+    # Otherwise: bayesian estimate around the forecast high
+    forecast_mean = state.forecast_high_f if state.forecast_high_f is not None else (
+        (state.current_high_f + max_env) / 2
+    )
+    # Clip the forecast to the envelope — reality can't exceed the envelope
+    forecast_mean = max(min_env, min(max_env, forecast_mean))
+    return p_normal_between(lo, hi, forecast_mean, FORECAST_STDDEV_F)

--- a/meteoedge-spike/kalshi_client.py
+++ b/meteoedge-spike/kalshi_client.py
@@ -1,7 +1,66 @@
+"""Minimal Kalshi API wrapper. Read-only endpoints for the spike."""
+import base64
+import time
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from config import KALSHI_API_BASE, KALSHI_API_KEY_ID, KALSHI_PRIVATE_KEY_PATH, HTTP_TIMEOUT_SECONDS, USER_AGENT
 
+
+def _load_private_key():
+    with open(KALSHI_PRIVATE_KEY_PATH, "rb") as f:
+        return serialization.load_pem_private_key(f.read(), password=None)
+
+
+def _sign_request(method: str, path: str) -> dict:
+    """Kalshi RSA-PSS request signing. Returns headers."""
+    private_key = _load_private_key()
+    timestamp = str(int(time.time() * 1000))
+    message = f"{timestamp}{method.upper()}{path}".encode("utf-8")
+
+    signature = private_key.sign(
+        message,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.DIGEST_LENGTH,
+        ),
+        hashes.SHA256(),
+    )
+
+    return {
+        "KALSHI-ACCESS-KEY": KALSHI_API_KEY_ID,
+        "KALSHI-ACCESS-SIGNATURE": base64.b64encode(signature).decode("utf-8"),
+        "KALSHI-ACCESS-TIMESTAMP": timestamp,
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+
+
 def get_weather_events() -> list[dict]:
-    return []
+    """Return all open weather events. The spike filters to daily-high only."""
+    path = "/events?status=open&category=Climate&with_nested_markets=true&limit=200"
+    url = f"{KALSHI_API_BASE}{path}"
+    try:
+        headers = _sign_request("GET", path)
+        r = httpx.get(url, headers=headers, timeout=HTTP_TIMEOUT_SECONDS)
+        r.raise_for_status()
+        return r.json().get("events", [])
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(f"Kalshi HTTP error {e.response.status_code}: {e.response.text}") from e
+    except Exception as e:
+        raise RuntimeError(f"Kalshi request failed: {e}") from e
+
 
 def get_orderbook(ticker: str) -> dict:
-    return {}
+    """Return the orderbook for a given market ticker."""
+    path = f"/markets/{ticker}/orderbook"
+    url = f"{KALSHI_API_BASE}{path}"
+    try:
+        headers = _sign_request("GET", path)
+        r = httpx.get(url, headers=headers, timeout=HTTP_TIMEOUT_SECONDS)
+        r.raise_for_status()
+        return r.json()
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(f"Kalshi HTTP error {e.response.status_code}: {e.response.text}") from e
+    except Exception as e:
+        raise RuntimeError(f"Kalshi orderbook request failed: {e}") from e

--- a/meteoedge-spike/spike.py
+++ b/meteoedge-spike/spike.py
@@ -1,20 +1,331 @@
-from config import (STATIONS, POLL_INTERVAL_SECONDS, MIN_EDGE_CENTS,
+"""Main polling loop. Run this script during trading hours."""
+import csv
+import json
+import time
+from datetime import datetime, timezone
+from dateutil import parser as dtparse
+import httpx
+from astral import LocationInfo
+from astral.sun import sun
+import pytz
+
+from config import (
+    STATIONS, POLL_INTERVAL_SECONDS, MIN_EDGE_CENTS,
     MIN_CONFIDENCE_YES, MAX_CONFIDENCE_YES_FOR_NO,
-    MIN_MINUTES_TO_SETTLEMENT, LOG_DIR, CANDIDATES_CSV, SNAPSHOTS_JSONL,
-    HTTP_TIMEOUT_SECONDS, USER_AGENT)
+    MIN_MINUTES_TO_SETTLEMENT, LOG_DIR, CANDIDATES_CSV,
+    SNAPSHOTS_JSONL, HTTP_TIMEOUT_SECONDS, USER_AGENT,
+)
 from envelope import Bracket, WeatherState, true_probability_yes
 from kalshi_client import get_weather_events
-import time
 
-STATION_TZ = {"KNYC": "America/New_York", "KORD": "America/Chicago",
-    "KMIA": "America/New_York", "KAUS": "America/Chicago", "KLAX": "America/Los_Angeles"}
+
+# --- Rough fee approximation for the spike.
+# Full spec requires the actual fee schedule; this is good enough for candidate flagging.
+def estimate_fee_cents(price_cents: int) -> float:
+    """Rough: 0.07 * price * (1 - price) per contract, 1¢ floor, in cents."""
+    p = price_cents / 100.0
+    return max(1.0, 7.0 * p * (1 - p))
+
+
+# --- Data fetchers
+def fetch_metar(station: str) -> dict | None:
+    url = f"https://aviationweather.gov/api/data/metar?ids={station}&format=json&hours=2"
+    try:
+        r = httpx.get(url, headers={"User-Agent": USER_AGENT}, timeout=HTTP_TIMEOUT_SECONDS)
+        r.raise_for_status()
+        data = r.json()
+        if not data:
+            return None
+        return data[0]  # most recent observation first
+    except Exception as e:
+        print(f"[metar] {station} error: {e}")
+        return None
+
+
+def fetch_all_metars_today(station: str) -> list[dict]:
+    url = f"https://aviationweather.gov/api/data/metar?ids={station}&format=json&hours=24"
+    try:
+        r = httpx.get(url, headers={"User-Agent": USER_AGENT}, timeout=HTTP_TIMEOUT_SECONDS)
+        r.raise_for_status()
+        return r.json() or []
+    except Exception as e:
+        print(f"[metar-day] {station} error: {e}")
+        return []
+
+
+def fetch_nws_forecast_high(lat: float, lon: float) -> float | None:
+    """Use the points API to discover the hourly forecast URL, then pull today's high."""
+    try:
+        points_url = f"https://api.weather.gov/points/{lat},{lon}"
+        r = httpx.get(points_url, headers={"User-Agent": USER_AGENT}, timeout=HTTP_TIMEOUT_SECONDS)
+        r.raise_for_status()
+        forecast_url = r.json()["properties"]["forecastHourly"]
+        r2 = httpx.get(forecast_url, headers={"User-Agent": USER_AGENT}, timeout=HTTP_TIMEOUT_SECONDS)
+        r2.raise_for_status()
+        periods = r2.json()["properties"]["periods"]
+        # Filter to periods ending today local
+        highs = [p["temperature"] for p in periods[:18] if p.get("temperatureUnit") == "F"]
+        return max(highs) if highs else None
+    except Exception as e:
+        print(f"[nws] {lat},{lon} error: {e}")
+        return None
+
+
+# --- Local time helpers
+STATION_TZ = {
+    "KNYC": "America/New_York",
+    "KORD": "America/Chicago",
+    "KMIA": "America/New_York",
+    "KAUS": "America/Chicago",
+    "KLAX": "America/Los_Angeles",
+}
+
+
+def now_local(station: str) -> datetime:
+    return datetime.now(pytz.timezone(STATION_TZ[station]))
+
+
+def sunset_local(station: str, lat: float, lon: float) -> datetime:
+    local_tz = pytz.timezone(STATION_TZ[station])
+    loc = LocationInfo(station, "US", STATION_TZ[station], lat, lon)
+    s = sun(loc.observer, date=datetime.now(local_tz).date(), tzinfo=local_tz)
+    return s["sunset"]
+
+
+# --- Running daily high
+def compute_daily_high(metars: list[dict], tz_name: str) -> tuple[float, datetime] | None:
+    tz = pytz.timezone(tz_name)
+    today_local_date = datetime.now(tz).date()
+    best_temp, best_time = None, None
+    for m in metars:
+        temp_c = m.get("temp")
+        obs_time_str = m.get("reportTime") or m.get("obsTime")
+        if temp_c is None or obs_time_str is None:
+            continue
+        try:
+            obs_time = dtparse.parse(obs_time_str)
+            if obs_time.tzinfo is None:
+                obs_time = obs_time.replace(tzinfo=timezone.utc)
+            obs_local = obs_time.astimezone(tz)
+            if obs_local.date() != today_local_date:
+                continue
+            temp_f = (float(temp_c) * 9 / 5) + 32
+            if best_temp is None or temp_f > best_temp:
+                best_temp, best_time = temp_f, obs_local
+        except Exception:
+            continue
+    if best_temp is None:
+        return None
+    return best_temp, best_time
+
+
+# --- Kalshi market parsing
+def parse_bracket_from_market(m: dict) -> "Bracket | None":
+    """Parse a Kalshi daily-high-temp market into a Bracket. Schema varies; inspect first."""
+    import re
+    ticker = m.get("ticker")
+    if not ticker:
+        return None
+
+    # The bracket bounds are encoded in the subtitle / rules_primary.
+    # Kalshi typically uses phrasings like "between 82 and 84°" or ">=85°".
+    sub = (m.get("subtitle") or m.get("yes_sub_title") or "").strip()
+
+    # Heuristic range parser — handles: "82-84", "82 to 84", "82–84"
+    m_range = re.search(r"(\d{1,3})\s*(?:-|to|–)\s*(\d{1,3})", sub)
+    # Handles: ">=85", "≥85", "85 or above", "85 or more", "85 or higher"
+    m_gte = re.search(r"(?:>=|≥|(\d{1,3})\s+or\s+(?:above|more|higher))", sub)
+    # Handles: "<=82", "≤82", "82 or below", "82 or less", "82 or lower"
+    m_lte = re.search(r"(?:<=|≤|(\d{1,3})\s+or\s+(?:below|less|lower))", sub)
+
+    # Also handle explicit >=N and <=N patterns with the number after the operator
+    m_gte_explicit = re.search(r"(?:>=|≥)\s*(\d{1,3})", sub)
+    m_lte_explicit = re.search(r"(?:<=|≤)\s*(\d{1,3})", sub)
+
+    if m_range:
+        lo, hi = float(m_range.group(1)), float(m_range.group(2))
+    elif m_gte_explicit:
+        lo, hi = float(m_gte_explicit.group(1)), 200.0
+    elif m_lte_explicit:
+        lo, hi = -50.0, float(m_lte_explicit.group(1))
+    elif m_gte and m_gte.group(1):
+        # "85 or above" form
+        lo, hi = float(m_gte.group(1)), 200.0
+    elif m_lte and m_lte.group(1):
+        # "82 or below" form
+        lo, hi = -50.0, float(m_lte.group(1))
+    else:
+        return None
+
+    return Bracket(
+        ticker=ticker,
+        low_f=lo,
+        high_f=hi,
+        yes_ask_cents=m.get("yes_ask") or 99,
+        yes_ask_size=m.get("yes_ask_size") or 0,
+        no_ask_cents=m.get("no_ask") or 99,
+        no_ask_size=m.get("no_ask_size") or 0,
+    )
+
+
+def is_daily_high_market(event: dict, market: dict) -> tuple[bool, "str | None"]:
+    """Identify daily-high-temperature markets and extract the station code."""
+    title = (event.get("title") or "").lower()
+    sub_title = (event.get("sub_title") or "").lower()
+    if "high" not in title and "high" not in sub_title:
+        return False, None
+    for station, _, _, city, _ in STATIONS:
+        if city.lower() in title or city.lower() in sub_title:
+            return True, station
+    return False, None
+
+
+# --- Main loop
+def append_candidate(row: dict):
+    LOG_DIR.mkdir(exist_ok=True)
+    new_file = not CANDIDATES_CSV.exists()
+    with open(CANDIDATES_CSV, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if new_file:
+            w.writeheader()
+        w.writerow(row)
+
+
+def append_snapshot(snap: dict):
+    LOG_DIR.mkdir(exist_ok=True)
+    with open(SNAPSHOTS_JSONL, "a") as f:
+        f.write(json.dumps(snap, default=str) + "\n")
+
+
+def minutes_to_settlement(market: dict) -> float:
+    close_str = market.get("close_time") or market.get("expiration_time")
+    if not close_str:
+        return 9999
+    try:
+        close = dtparse.parse(close_str)
+        if close.tzinfo is None:
+            close = close.replace(tzinfo=timezone.utc)
+        return (close - datetime.now(timezone.utc)).total_seconds() / 60
+    except Exception:
+        return 9999
+
 
 def poll_once():
-    pass
+    ts = datetime.now(timezone.utc).isoformat()
+    print(f"\n=== Poll at {ts} ===")
+
+    # 1. Build weather state per station
+    weather: dict[str, WeatherState] = {}
+    for station, lat, lon, city, _ in STATIONS:
+        metars = fetch_all_metars_today(station)
+        latest = metars[0] if metars else None
+        if not latest:
+            print(f"[{station}] no METAR data available, skipping")
+            continue
+        high = compute_daily_high(metars, STATION_TZ[station])
+        if not high:
+            print(f"[{station}] could not compute daily high, skipping")
+            continue
+        high_f, high_time = high
+        try:
+            latest_temp_c = latest.get("temp")
+            if latest_temp_c is None:
+                print(f"[{station}] latest METAR missing temp field, skipping")
+                continue
+            latest_temp_f = (float(latest_temp_c) * 9 / 5) + 32
+            obs_time_str = latest.get("reportTime") or latest.get("obsTime")
+            if obs_time_str is None:
+                print(f"[{station}] latest METAR missing time field, skipping")
+                continue
+            latest_time = dtparse.parse(obs_time_str)
+            if latest_time.tzinfo is None:
+                latest_time = latest_time.replace(tzinfo=timezone.utc)
+        except Exception as e:
+            print(f"[{station}] METAR parse error: {e}, skipping")
+            continue
+        forecast_high = fetch_nws_forecast_high(lat, lon)
+        weather[station] = WeatherState(
+            station=station,
+            now_local=now_local(station),
+            sunset_local=sunset_local(station, lat, lon),
+            current_high_f=high_f,
+            current_high_time=high_time,
+            latest_temp_f=latest_temp_f,
+            latest_temp_time=latest_time,
+            forecast_high_f=forecast_high,
+        )
+        print(f"[{station}] current_high={high_f:.1f}°F latest={latest_temp_f:.1f}°F forecast={forecast_high}")
+
+    # 2. Pull Kalshi events and scan
+    try:
+        events = get_weather_events()
+    except Exception as e:
+        print(f"[kalshi] error fetching events: {e}. Skipping this poll.")
+        return
+
+    for event in events:
+        for market in event.get("markets", []):
+            try:
+                is_daily, station = is_daily_high_market(event, market)
+                if not is_daily or station not in weather:
+                    continue
+                mins_left = minutes_to_settlement(market)
+                if mins_left < MIN_MINUTES_TO_SETTLEMENT:
+                    continue
+                bracket = parse_bracket_from_market(market)
+                if not bracket:
+                    continue
+
+                state = weather[station]
+                p_yes = true_probability_yes(bracket, state)
+                fee = estimate_fee_cents(min(bracket.yes_ask_cents, bracket.no_ask_cents))
+
+                ev_yes = p_yes * 100 - bracket.yes_ask_cents - fee
+                ev_no = (1 - p_yes) * 100 - bracket.no_ask_cents - fee
+
+                candidate = None
+                if ev_yes >= MIN_EDGE_CENTS and p_yes >= MIN_CONFIDENCE_YES:
+                    candidate = ("YES", ev_yes, bracket.yes_ask_cents, p_yes)
+                elif ev_no >= MIN_EDGE_CENTS and p_yes <= MAX_CONFIDENCE_YES_FOR_NO:
+                    candidate = ("NO", ev_no, bracket.no_ask_cents, 1 - p_yes)
+
+                snap = {
+                    "ts": ts, "station": station, "ticker": bracket.ticker,
+                    "bracket_low": bracket.low_f, "bracket_high": bracket.high_f,
+                    "yes_ask": bracket.yes_ask_cents, "no_ask": bracket.no_ask_cents,
+                    "current_high": state.current_high_f, "latest_temp": state.latest_temp_f,
+                    "forecast_high": state.forecast_high_f, "p_yes": round(p_yes, 4),
+                    "ev_yes": round(ev_yes, 2), "ev_no": round(ev_no, 2),
+                    "minutes_to_settlement": round(mins_left, 1),
+                }
+                append_snapshot(snap)
+
+                if candidate:
+                    side, edge, price, confidence = candidate
+                    row = {**snap, "flagged_side": side, "flagged_edge": round(edge, 2),
+                           "flagged_price": price, "flagged_confidence": round(confidence, 4)}
+                    append_candidate(row)
+                    print(f"  ** FLAGGED {bracket.ticker} {side} @ {price}¢ edge={edge:.2f}¢ p={confidence:.2%}")
+
+            except Exception as e:
+                ticker = market.get("ticker", "unknown")
+                print(f"[market] error processing {ticker}: {e}, skipping")
+                continue
+
 
 def main():
     print("MeteoEdge spike starting. Observe-only mode.")
     print("Ctrl-C to stop. Logs under ./logs/")
+    while True:
+        try:
+            poll_once()
+        except KeyboardInterrupt:
+            print("\nStopping.")
+            break
+        except Exception as e:
+            print(f"[loop] unhandled error: {e}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
 
 if __name__ == "__main__":
     main()

--- a/meteoedge-spike/tests/test_envelope.py
+++ b/meteoedge-spike/tests/test_envelope.py
@@ -1,0 +1,302 @@
+"""Unit tests for envelope.py pure math functions.
+No external API calls required — all tests use synthetic inputs.
+"""
+import sys
+import os
+import pytest
+from datetime import datetime
+from math import isclose
+
+# Ensure meteoedge-spike is on the path so imports resolve without installation
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from envelope import (
+    Bracket,
+    WeatherState,
+    p_normal_between,
+    compute_envelope,
+    true_probability_yes,
+    expected_additional_rise,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_state(
+    current_high_f: float = 80.0,
+    latest_temp_f: float = 80.0,
+    forecast_high_f: float | None = 81.0,
+    hour: int = 14,
+    station: str = "KNYC",
+) -> WeatherState:
+    """Build a WeatherState with sensible defaults for testing."""
+    now = datetime(2024, 7, 15, hour, 30)
+    return WeatherState(
+        station=station,
+        now_local=now,
+        sunset_local=datetime(2024, 7, 15, 20, 15),
+        current_high_f=current_high_f,
+        current_high_time=now,
+        latest_temp_f=latest_temp_f,
+        latest_temp_time=now,
+        forecast_high_f=forecast_high_f,
+    )
+
+
+def make_bracket(
+    low_f: float,
+    high_f: float,
+    yes_ask_cents: int = 50,
+    no_ask_cents: int = 52,
+) -> Bracket:
+    return Bracket(
+        ticker="TEST-TICKER",
+        low_f=low_f,
+        high_f=high_f,
+        yes_ask_cents=yes_ask_cents,
+        yes_ask_size=100,
+        no_ask_cents=no_ask_cents,
+        no_ask_size=100,
+    )
+
+
+# ---------------------------------------------------------------------------
+# p_normal_between tests
+# ---------------------------------------------------------------------------
+
+class TestPNormalBetween:
+    def test_known_value_symmetric_interval(self):
+        """P(80 <= X <= 82) where X~N(81, 2^2).
+        By symmetry this equals 2*Phi(0.5) - 1 ≈ 0.3829.
+        """
+        result = p_normal_between(80.0, 82.0, mean=81.0, stddev=2.0)
+        assert isclose(result, 0.3829, abs_tol=0.001), f"Got {result}"
+
+    def test_wide_interval_near_one(self):
+        """P(-100 <= X <= 100) where X~N(50, 5^2) should be essentially 1."""
+        result = p_normal_between(-100.0, 100.0, mean=50.0, stddev=5.0)
+        assert result > 0.9999
+
+    def test_interval_far_from_mean_near_zero(self):
+        """P(200 <= X <= 210) where X~N(80, 2^2) should be ~0."""
+        result = p_normal_between(200.0, 210.0, mean=80.0, stddev=2.0)
+        assert result < 1e-6
+
+    def test_clamps_to_zero(self):
+        """Result must never be negative."""
+        result = p_normal_between(100.0, 90.0, mean=80.0, stddev=2.0)
+        assert result == 0.0
+
+    def test_clamps_to_one(self):
+        """Result must never exceed 1."""
+        result = p_normal_between(-1000.0, 1000.0, mean=0.0, stddev=1.0)
+        assert result == 1.0
+
+    def test_symmetric_around_mean(self):
+        """P(mean-d <= X <= mean) == P(mean <= X <= mean+d) by symmetry."""
+        mean, d, stddev = 75.0, 3.0, 2.0
+        left = p_normal_between(mean - d, mean, mean=mean, stddev=stddev)
+        right = p_normal_between(mean, mean + d, mean=mean, stddev=stddev)
+        assert isclose(left, right, abs_tol=1e-10)
+
+    def test_point_interval_near_zero(self):
+        """P(X == 81) is 0 for a continuous distribution."""
+        result = p_normal_between(81.0, 81.0, mean=81.0, stddev=2.0)
+        # CDF(81) - CDF(81) = 0
+        assert result == 0.0
+
+    def test_known_value_one_sigma(self):
+        """P(mean - sigma <= X <= mean + sigma) ≈ 0.6827."""
+        mean, stddev = 80.0, 3.0
+        result = p_normal_between(mean - stddev, mean + stddev, mean=mean, stddev=stddev)
+        assert isclose(result, 0.6827, abs_tol=0.001), f"Got {result}"
+
+
+# ---------------------------------------------------------------------------
+# compute_envelope tests
+# ---------------------------------------------------------------------------
+
+class TestComputeEnvelope:
+    def test_min_high_equals_current_high(self):
+        """min_plausible_high is always the current recorded daily high."""
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        min_high, _ = compute_envelope(state)
+        assert min_high == 82.0
+
+    def test_max_high_gte_current_high(self):
+        """max_plausible_high must be >= current_high_f (daily high can't go down)."""
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        _, max_high = compute_envelope(state)
+        assert max_high >= 82.0
+
+    def test_max_high_uses_climb_from_latest_temp(self):
+        """At hour 14, DEFAULT_CLIMB_LOOKUP[14]=4. latest_temp=80 -> max = max(82, 80+4)=84."""
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 82.0
+        assert max_high == 84.0
+
+    def test_max_high_when_latest_temp_above_high(self):
+        """latest_temp may equal current high (e.g. rising all day)."""
+        # hour=12, climb=6: max = max(85, 85+6) = 91
+        state = make_state(current_high_f=85.0, latest_temp_f=85.0, hour=12)
+        _, max_high = compute_envelope(state)
+        assert max_high == 91.0
+
+    def test_no_rise_after_hour_20(self):
+        """After 8pm, expected additional rise is 0; max_high == current_high if no more climb."""
+        # latest_temp == current_high at hour 21; no further climb expected
+        state = make_state(current_high_f=88.0, latest_temp_f=88.0, hour=21)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 88.0
+        assert max_high == 88.0
+
+    def test_envelope_bounds_when_latest_temp_lower(self):
+        """If latest_temp is below current high, max = max(current_high, latest_temp + climb)."""
+        # hour=15, climb=3: max = max(85, 79+3) = max(85, 82) = 85
+        state = make_state(current_high_f=85.0, latest_temp_f=79.0, hour=15)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 85.0
+        assert max_high == 85.0
+
+
+# ---------------------------------------------------------------------------
+# true_probability_yes tests
+# ---------------------------------------------------------------------------
+
+class TestTrueProbabilityYes:
+    def test_bracket_below_current_high_returns_zero(self):
+        """A bracket whose top is below the current daily high is impossible (returns 0.0)."""
+        # current_high=85, bracket is [78, 84]
+        state = make_state(current_high_f=85.0, latest_temp_f=83.0, hour=15)
+        bracket = make_bracket(low_f=78.0, high_f=84.0)
+        assert true_probability_yes(bracket, state) == 0.0
+
+    def test_bracket_above_envelope_returns_zero(self):
+        """A bracket above the max envelope is physically impossible (returns 0.0)."""
+        # hour=21, no climb; current_high=85, latest=85 -> max_env=85
+        # bracket [90, 95] is above envelope
+        state = make_state(current_high_f=85.0, latest_temp_f=85.0, hour=21)
+        bracket = make_bracket(low_f=90.0, high_f=95.0)
+        assert true_probability_yes(bracket, state) == 0.0
+
+    def test_bracket_contains_full_envelope_returns_one(self):
+        """If the bracket fully contains [current_high, max_env], the outcome is certain (1.0)."""
+        # hour=21, no climb; current_high=82, max_env=82
+        # bracket [70, 90] fully contains envelope [82, 82]
+        state = make_state(current_high_f=82.0, latest_temp_f=82.0, hour=21)
+        bracket = make_bracket(low_f=70.0, high_f=90.0)
+        assert true_probability_yes(bracket, state) == 1.0
+
+    def test_exact_envelope_bracket_returns_one(self):
+        """A bracket exactly matching [current_high, max_env] returns 1.0."""
+        # hour=21; current_high=82 => min_env=82, max_env=82
+        state = make_state(current_high_f=82.0, latest_temp_f=82.0, hour=21)
+        bracket = make_bracket(low_f=82.0, high_f=82.0)
+        assert true_probability_yes(bracket, state) == 1.0
+
+    def test_bayesian_case_uses_forecast(self):
+        """Partial bracket — result should be a p_normal_between value, 0 < p < 1."""
+        # hour=21; current_high=80, max_env=80; forecast=80
+        # bracket [78, 82] overlaps but doesn't fully contain
+        # Bracket hi(82) >= current_high(80) and lo(78) <= current_high(80),
+        # but hi(82) > max_env(80) — so lo <= current_high and hi >= max_env → returns 1.0
+        # Use a mid-day scenario where there's still uncertainty
+        state = make_state(current_high_f=80.0, latest_temp_f=79.0, hour=14, forecast_high_f=82.0)
+        # hour=14, climb=4; max_env = max(80, 79+4) = 83
+        # bracket [81, 85]: lo(81) > current_high(80) but lo(81) <= max_env(83)
+        # doesn't trigger either shortcut -> bayesian
+        bracket = make_bracket(low_f=81.0, high_f=85.0)
+        result = true_probability_yes(bracket, state)
+        assert 0.0 < result < 1.0
+
+    def test_no_forecast_falls_back_to_midpoint(self):
+        """With no forecast, mean is (current_high + max_env) / 2."""
+        state = make_state(current_high_f=80.0, latest_temp_f=79.0, hour=14, forecast_high_f=None)
+        # max_env = max(80, 79+4) = 83; midpoint mean = (80+83)/2 = 81.5
+        bracket = make_bracket(low_f=80.0, high_f=83.0)
+        result = true_probability_yes(bracket, state)
+        # Should be near 1.0 since bracket fully contains envelope
+        assert result == 1.0
+
+    def test_high_confidence_no_side(self):
+        """A bracket well above forecast should yield very low p_yes."""
+        # forecast=80, stddev=2; bracket [95, 100] is 7.5+ sigma away
+        state = make_state(current_high_f=79.0, latest_temp_f=78.0, hour=14, forecast_high_f=80.0)
+        # max_env = max(79, 78+4) = 82; bracket [95,100] > max_env(82) -> returns 0.0
+        bracket = make_bracket(low_f=95.0, high_f=100.0)
+        result = true_probability_yes(bracket, state)
+        assert result == 0.0
+
+    def test_probability_bounded_zero_to_one(self):
+        """Result is always in [0, 1]."""
+        state = make_state(current_high_f=82.0, latest_temp_f=81.0, hour=13, forecast_high_f=84.0)
+        for lo, hi in [(70, 75), (80, 85), (85, 90), (100, 110)]:
+            bracket = make_bracket(low_f=float(lo), high_f=float(hi))
+            result = true_probability_yes(bracket, state)
+            assert 0.0 <= result <= 1.0, f"Out of bounds for [{lo}, {hi}]: {result}"
+
+
+# ---------------------------------------------------------------------------
+# parse_bracket_from_market tests (no API calls — pure parsing)
+# ---------------------------------------------------------------------------
+
+class TestParseBracketFromMarket:
+    """Test the regex parsing in spike.parse_bracket_from_market."""
+
+    def setup_method(self):
+        # Import here so test file doesn't require spike's runtime deps at module level
+        import importlib.util
+        import sys as _sys
+        spec_path = os.path.join(os.path.dirname(__file__), "..", "spike.py")
+        spec = importlib.util.spec_from_file_location("spike_module", spec_path)
+        mod = importlib.util.module_from_spec(spec)
+        # We need the deps available; skip if not installed
+        try:
+            spec.loader.exec_module(mod)
+            self.parse = mod.parse_bracket_from_market
+        except ImportError:
+            pytest.skip("spike.py runtime deps not installed")
+
+    def _market(self, subtitle: str, ticker: str = "T-TEST") -> dict:
+        return {"ticker": ticker, "subtitle": subtitle}
+
+    def test_range_dash(self):
+        b = self.parse(self._market("82-84°"))
+        assert b is not None
+        assert b.low_f == 82.0
+        assert b.high_f == 84.0
+
+    def test_range_to(self):
+        b = self.parse(self._market("82 to 84 degrees"))
+        assert b is not None
+        assert b.low_f == 82.0
+        assert b.high_f == 84.0
+
+    def test_range_em_dash(self):
+        b = self.parse(self._market("82–84°"))
+        assert b is not None
+        assert b.low_f == 82.0
+        assert b.high_f == 84.0
+
+    def test_gte_symbol(self):
+        b = self.parse(self._market(">=85°"))
+        assert b is not None
+        assert b.low_f == 85.0
+        assert b.high_f == 200.0
+
+    def test_lte_symbol(self):
+        b = self.parse(self._market("<=82°"))
+        assert b is not None
+        assert b.low_f == -50.0
+        assert b.high_f == 82.0
+
+    def test_unrecognized_returns_none(self):
+        b = self.parse(self._market("something unexpected 999xyz"))
+        assert b is None
+
+    def test_missing_ticker_returns_none(self):
+        b = self.parse({"subtitle": "82-84°"})
+        assert b is None


### PR DESCRIPTION
## Closes #3

## What changed

Replaced stub files with full implementations from the MVP spike spec (§5.2–5.4):

### `meteoedge-spike/kalshi_client.py`
- Full RSA-PSS request signing with `cryptography` library
- `get_weather_events()` and `get_orderbook()` raise `RuntimeError` on HTTP/network failure so the caller in `spike.py` can catch-and-log cleanly

### `meteoedge-spike/envelope.py`
- `p_normal_between(low, high, mean, stddev)` — CDF-based normal probability clamped to [0, 1]
- `expected_additional_rise(station, now_local)` — p95 climb lookup from `DEFAULT_CLIMB_LOOKUP`
- `compute_envelope(state)` — returns `(min_plausible_high, max_plausible_high)`
- `true_probability_yes(bracket, state)` — three-path: definite 0.0, definite 1.0, or Bayesian estimate via forecast mean

### `meteoedge-spike/spike.py`
- Full METAR fetch with per-field null checks — missing `temp` or `obsTime` are logged and skipped, never crash
- NWS forecast fetch wrapped in exception catch-and-log
- `compute_daily_high()` iterates all today's METARs, skips malformed records, returns running max
- `parse_bracket_from_market()` — hardened regex for `"82-84"`, `">=85"`, `"<=82"`, `"82 to 84"`, and natural-language variants (`"or above"`, `"or below"`)
- `poll_once()` — each market processed inside try/except so one bad market never aborts the poll
- `main()` — `KeyboardInterrupt` exits cleanly; all other exceptions are caught, logged, loop continues

### `meteoedge-spike/tests/test_envelope.py` (new)
29 unit tests, zero external API calls:
- `TestPNormalBetween` (8 tests) — known numerical values, clamping, symmetry, one-sigma
- `TestComputeEnvelope` (6 tests) — min == current_high, max uses climb lookup, no rise after hour 20
- `TestTrueProbabilityYes` (8 tests) — definite 0/1 cases, Bayesian path, forecast fallback, output bounds
- `TestParseBracketFromMarket` (7 tests) — range `dash`/`to`/`em-dash`, `>=`, `<=`, unrecognised, missing ticker

## How to test

```bash
cd meteoedge-spike
python -m pytest tests/test_envelope.py -v   # 29 passed
```

For a live smoke test (requires Kalshi credentials in `keys/` and `config.py`):
```bash
python spike.py   # one poll then waits 5 min; Ctrl-C exits cleanly
```