### PR TITLE
E0 data layer modules: METAR, NWS, Open-Meteo

### DIFF
--- a/src/data/metar.py
+++ b/src/data/metar.py
@@ -1,0 +1,94 @@
+"""METAR data fetcher — aviation weather observations for each station.
+
+All HTTP calls go through http_client for rate limiting, retry, and caching.
+STATION_TZ is imported from src.config to avoid duplication.
+"""
+from datetime import datetime
+from dateutil import parser as dtparse
+from datetime import timezone
+import pytz
+from astral import LocationInfo
+from astral.sun import sun
+
+from src.config import STATION_TZ, HTTP_TIMEOUT_SECONDS
+from src.http_client import fetch
+
+
+def fetch_metar(station: str) -> dict | None:
+    """Fetch the latest METAR observation for a station.
+
+    Returns the most recent METAR report as a dict with keys like 'temp',
+    'reportTime', 'obsTime', etc. Returns None on error.
+    """
+    url = f"https://aviationweather.gov/api/data/metar?ids={station}&format=json&hours=2"
+    try:
+        r = fetch(url, timeout=HTTP_TIMEOUT_SECONDS)
+        data = r.json()
+        if not data:
+            return None
+        return data[0]
+    except Exception as e:
+        print(f"[metar] {station} error: {e}")
+        return None
+
+
+def fetch_all_metars_today(station: str) -> list[dict]:
+    """Fetch all METAR observations for a station in the last 24 hours.
+
+    Returns a list of METAR reports as dicts. Returns empty list on error.
+    """
+    url = f"https://aviationweather.gov/api/data/metar?ids={station}&format=json&hours=24"
+    try:
+        r = fetch(url, timeout=HTTP_TIMEOUT_SECONDS)
+        return r.json() or []
+    except Exception as e:
+        print(f"[metar-day] {station} error: {e}")
+        return []
+
+
+def now_local(station: str) -> datetime:
+    """Return the current time in the local timezone of the given station."""
+    return datetime.now(pytz.timezone(STATION_TZ[station]))
+
+
+def sunset_local(station: str, lat: float, lon: float) -> datetime:
+    """Return sunset time (as a datetime) in the local timezone of the given station."""
+    local_tz = pytz.timezone(STATION_TZ[station])
+    loc = LocationInfo(station, "US", STATION_TZ[station], lat, lon)
+    s = sun(loc.observer, date=datetime.now(local_tz).date(), tzinfo=local_tz)
+    return s["sunset"]
+
+
+def compute_daily_high(metars: list[dict], tz_name: str) -> tuple[float, datetime] | None:
+    """Compute today's daily high temperature from a list of METAR observations.
+
+    Args:
+        metars: List of METAR report dicts (each containing 'temp', 'reportTime'/'obsTime', etc.)
+        tz_name: Timezone name (e.g., 'America/New_York')
+
+    Returns:
+        Tuple of (high_temp_f, obs_time_local) for today's high, or None if no valid observations.
+    """
+    tz = pytz.timezone(tz_name)
+    today_local_date = datetime.now(tz).date()
+    best_temp, best_time = None, None
+    for m in metars:
+        temp_c = m.get("temp")
+        obs_time_str = m.get("reportTime") or m.get("obsTime")
+        if temp_c is None or obs_time_str is None:
+            continue
+        try:
+            obs_time = dtparse.parse(obs_time_str)
+            if obs_time.tzinfo is None:
+                obs_time = obs_time.replace(tzinfo=timezone.utc)
+            obs_local = obs_time.astimezone(tz)
+            if obs_local.date() != today_local_date:
+                continue
+            temp_f = (float(temp_c) * 9 / 5) + 32
+            if best_temp is None or temp_f > best_temp:
+                best_temp, best_time = temp_f, obs_local
+        except Exception:
+            continue
+    if best_temp is None:
+        return None
+    return best_temp, best_time

--- a/src/data/nws.py
+++ b/src/data/nws.py
@@ -1,0 +1,27 @@
+"""NWS forecast fetcher — uses http_client's NWS /points permanent cache
+and 30-min TTL for forecast data.
+"""
+from src.http_client import get_nws_forecast_url, cached_fetch_json
+
+
+def fetch_nws_forecast_high(lat: float, lon: float) -> float | None:
+    """Return today's forecast high (°F) for lat/lon using NWS hourly forecast.
+
+    Uses http_client's permanent /points cache and 30-min forecast cache.
+    Returns None if the forecast is unavailable.
+    """
+    forecast_url = get_nws_forecast_url(lat, lon)
+    if not forecast_url:
+        return None
+
+    data = cached_fetch_json(forecast_url, ttl_minutes=30)
+    if not data:
+        return None
+
+    try:
+        periods = data["properties"]["periods"]
+        highs = [p["temperature"] for p in periods[:18] if p.get("temperatureUnit") == "F"]
+        return max(highs) if highs else None
+    except Exception as e:
+        print(f"[nws] parse error for ({lat},{lon}): {e}")
+        return None

--- a/src/data/open_meteo.py
+++ b/src/data/open_meteo.py
@@ -1,0 +1,29 @@
+"""Open-Meteo secondary forecast source.
+
+Used as a weighted secondary input (40%) alongside NWS (60%) in the ensemble.
+Cached 30 min — Open-Meteo updates hourly and the free tier caps at 10,000 req/day.
+"""
+from src.http_client import cached_fetch_json
+
+
+def fetch_secondary_forecast(lat: float, lon: float) -> float | None:
+    """Fetch forecast daily high (°F) from Open-Meteo for the given coordinates.
+
+    Cached 30 min per coordinate pair.
+    Returns None if unavailable.
+    """
+    url = (
+        f"https://api.open-meteo.com/v1/forecast"
+        f"?latitude={lat}&longitude={lon}"
+        f"&hourly=temperature_2m,weather_code"
+        f"&temperature_unit=fahrenheit&timezone=auto"
+    )
+    data = cached_fetch_json(url, ttl_minutes=30)
+    if not data:
+        return None
+    try:
+        temps = data["hourly"]["temperature_2m"][:24]
+        return max(temps) if temps else None
+    except Exception as e:
+        print(f"[open-meteo] parse error for ({lat},{lon}): {e}")
+        return None


### PR DESCRIPTION
## Summary
Creates the three data-layer modules for Epic 0 (closes #34, closes #35, closes #36).

- `src/data/metar.py`: METAR fetcher — fetch_metar, fetch_all_metars_today, compute_daily_high, now_local, sunset_local extracted from archive/spike.py; all HTTP calls via http_client.fetch
- `src/data/nws.py`: NWS forecast high extractor — uses http_client's permanent /points cache + 30-min forecast TTL
- `src/data/open_meteo.py`: Open-Meteo secondary forecast — promoted from improved_envelope.py

All modules import STATION_TZ from src.config. No direct httpx imports.

Closes #34
Closes #35
Closes #36

## How to test
python -c "from src.data.metar import fetch_metar, compute_daily_high; from src.data.nws import fetch_nws_forecast_high; from src.data.open_meteo import fetch_secondary_forecast; print('all imports OK')"