### PR TITLE
E0-5/E0-6: Add src/data/polymarket.py and src/model/envelope+climb_rates

### DIFF
--- a/src/data/polymarket.py
+++ b/src/data/polymarket.py
@@ -1,0 +1,53 @@
+"""Polymarket API client. No authentication required for read-only access."""
+from src.http_client import cached_fetch_json, fetch
+from src.config import (
+    POLYMARKET_GAMMA_API, POLYMARKET_CLOB_API,
+    POLYMARKET_WEATHER_TAG_ID, HTTP_TIMEOUT_SECONDS,
+)
+
+
+def get_weather_markets() -> list[dict]:
+    """Fetch all active weather-tagged markets via Polymarket Gamma API.
+
+    Paginated (100 per page). Each page URL is cached for 5 min so back-to-back
+    polls don't re-fetch. Markets open/close infrequently within a session.
+    """
+    all_markets: list[dict] = []
+    seen_ids: set[str] = set()
+
+    for offset in range(0, 5000, 100):
+        url = (
+            f"{POLYMARKET_GAMMA_API}/markets"
+            f"?limit=100&active=true&closed=false"
+            f"&tag_id={POLYMARKET_WEATHER_TAG_ID}&offset={offset}"
+        )
+        data = cached_fetch_json(url, ttl_minutes=5)
+        if data is None:
+            print(f"[polymarket] offset={offset} fetch failed, stopping pagination")
+            break
+        batch = data if isinstance(data, list) else data.get("markets", [])
+        if not batch:
+            break
+        for m in batch:
+            mid = m.get("conditionId") or m.get("condition_id") or m.get("id")
+            if mid and mid not in seen_ids:
+                seen_ids.add(mid)
+                all_markets.append(m)
+        if len(batch) < 100:
+            break
+
+    return all_markets
+
+
+def get_orderbook(token_id: str) -> dict:
+    """Fetch live CLOB order book for a single token (YES or NO side).
+
+    Not cached — the orderbook changes tick by tick.
+    Returns dict with 'bids' and 'asks' lists of {price: str, size: str}.
+    """
+    url = f"{POLYMARKET_CLOB_API}/book?token_id={token_id}"
+    try:
+        r = fetch(url, timeout=HTTP_TIMEOUT_SECONDS)
+        return r.json()
+    except Exception as e:
+        raise RuntimeError(f"Polymarket CLOB request failed for token {token_id}: {e}") from e

--- a/src/model/climb_rates.py
+++ b/src/model/climb_rates.py
@@ -1,0 +1,32 @@
+"""Per-month climb rate tables (°F of additional rise possible from each hour of day).
+
+Keys: month number (1=Jan ... 12=Dec)
+Values: dict mapping hour-of-day (0–23) to p95 additional rise in °F.
+
+Currently only May (month 5) is calibrated from historical data.
+All other months use May as a conservative placeholder.
+Epic 5, issue E5-3 will derive accurate per-city values from NOAA METAR archives.
+"""
+
+_MAY: dict[int, float] = {
+    0: 22.0, 1: 22.0, 2: 21.0, 3: 20.0, 4: 19.0, 5: 18.0,
+    6: 16.0, 7: 14.0, 8: 12.0, 9: 10.0, 10: 8.0, 11: 7.0,
+    12: 6.0, 13: 5.0, 14: 4.5, 15: 3.5, 16: 2.5, 17: 1.5,
+    18: 0.5, 19: 0.0, 20: 0.0, 21: 0.0, 22: 0.0, 23: 0.0,
+}
+
+CLIMB_BY_MONTH: dict[int, dict[int, float]] = {m: _MAY for m in range(1, 13)}
+
+
+def expected_additional_rise(now_local) -> float:
+    """Return p95 additional °F rise from now_local.hour to end-of-day.
+
+    Args:
+        now_local: datetime in the station's local timezone
+    Returns:
+        Expected additional rise in °F (0.0 if no further rise expected)
+    """
+    month = now_local.month
+    hour = now_local.hour
+    table = CLIMB_BY_MONTH.get(month, _MAY)
+    return table.get(hour, 0.0)

--- a/src/model/envelope.py
+++ b/src/model/envelope.py
@@ -1,9 +1,14 @@
-"""Enhanced envelope with better climb rates, forecast ensemble, and time-to-settlement adjustment."""
+"""Weather envelope model: computes plausible daily high range and YES probability.
+
+Promoted from src/improved_envelope.py. fetch_secondary_forecast has moved to
+src/data/open_meteo.py. Climb rates are now sourced from src/model/climb_rates.py.
+"""
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from math import erf, sqrt
 
-from http_client import cached_fetch_json
+from src.model.climb_rates import expected_additional_rise
+
 
 @dataclass
 class WeatherState:
@@ -17,6 +22,7 @@ class WeatherState:
     forecast_high_f: float | None
     secondary_forecast_f: float | None = None
 
+
 @dataclass
 class Bracket:
     ticker: str
@@ -29,13 +35,6 @@ class Bracket:
     yes_token_id: str | None = None
     no_token_id: str | None = None
 
-# Improved climb rates derived from seasonal patterns
-CLIMB_LOOKUP_SPRING = {  # May
-    0: 22.0, 1: 22.0, 2: 21.0, 3: 20.0, 4: 19.0, 5: 18.0,
-    6: 16.0, 7: 14.0, 8: 12.0, 9: 10.0, 10: 8.0, 11: 7.0,
-    12: 6.0, 13: 5.0, 14: 4.5, 15: 3.5, 16: 2.5, 17: 1.5,
-    18: 0.5, 19: 0.0, 20: 0.0, 21: 0.0, 22: 0.0, 23: 0.0,
-}
 
 def p_normal_between(low: float, high: float, mean: float, stddev: float) -> float:
     """P(low <= X <= high) for X ~ N(mean, stddev^2)."""
@@ -43,40 +42,13 @@ def p_normal_between(low: float, high: float, mean: float, stddev: float) -> flo
         return 0.5 * (1 + erf((x - mean) / (stddev * sqrt(2))))
     return max(0.0, min(1.0, cdf(high) - cdf(low)))
 
-def expected_additional_rise(station: str, now_local: datetime) -> float:
-    """Improved: use seasonal climb rates."""
-    hour = now_local.hour
-    # For now, use spring rates (May). In production, would vary by month.
-    return CLIMB_LOOKUP_SPRING.get(hour, 0.0)
-
-def fetch_secondary_forecast(lat: float, lon: float) -> float | None:
-    """Fetch from Open-Meteo as secondary forecast source.
-
-    Cached for 30 minutes — Open-Meteo updates hourly and the free tier
-    caps at 10 000 req/day.  With 11 stations every 5 min that would be
-    ~3 168 req/day uncached; caching reduces it to ~528 req/day.
-    """
-    url = (
-        f"https://api.open-meteo.com/v1/forecast"
-        f"?latitude={lat}&longitude={lon}"
-        f"&hourly=temperature_2m,weather_code"
-        f"&temperature_unit=fahrenheit&timezone=auto"
-    )
-    data = cached_fetch_json(url, ttl_minutes=30)
-    if not data:
-        return None
-    try:
-        temps = data["hourly"]["temperature_2m"][:24]
-        return max(temps) if temps else None
-    except Exception as e:
-        print(f"[secondary-forecast] parse error: {e}")
-        return None
 
 def ensemble_forecast(primary: float | None, secondary: float | None) -> float | None:
     """Combine multiple forecast sources."""
     if primary and secondary:
         return (primary * 0.6 + secondary * 0.4)  # Weight NWS heavier (proven accuracy)
     return primary or secondary
+
 
 def time_to_settlement_boost(p: float, minutes_left: float) -> float:
     """Boost confidence as settlement approaches and actual temp is nearly determined."""
@@ -86,20 +58,23 @@ def time_to_settlement_boost(p: float, minutes_left: float) -> float:
         return p + (p - 0.5) * 0.2 * (1 - minutes_left / 60)
     return p
 
-def compute_envelope(state: WeatherState, minutes_to_settlement: float) -> tuple[float, float]:
+
+def compute_envelope(state: WeatherState, minutes_to_settlement: float = 9999.0) -> tuple[float, float]:
     """Return (min_plausible_high, max_plausible_high) for the rest of the day."""
     min_high = state.current_high_f
-    additional = expected_additional_rise(state.station, state.now_local)
+    additional = expected_additional_rise(state.now_local)
     max_high = max(
         state.current_high_f,
         state.latest_temp_f + additional,
     )
     return min_high, max_high
 
-def true_probability_yes(bracket: Bracket, state: WeatherState, minutes_to_settlement: float,
+
+def true_probability_yes(bracket: Bracket, state: WeatherState,
+                         minutes_to_settlement: float = 9999.0,
                          forecast_stddev: float = 2.0) -> float:
-    """
-    Compute P(daily high falls in this bracket).
+    """Compute P(daily high falls in this bracket).
+
     Enhanced: uses ensemble forecast and time-to-settlement boost.
     """
     lo, hi = bracket.low_f, bracket.high_f

--- a/src/tests/test_climb_rates.py
+++ b/src/tests/test_climb_rates.py
@@ -1,0 +1,58 @@
+"""Unit tests for src/model/climb_rates.py."""
+from datetime import datetime
+
+import pytest
+
+from src.model.climb_rates import CLIMB_BY_MONTH, expected_additional_rise
+
+
+class TestClimbByMonth:
+    def test_has_all_twelve_months(self):
+        assert len(CLIMB_BY_MONTH) == 12
+
+    def test_months_are_one_to_twelve(self):
+        assert set(CLIMB_BY_MONTH.keys()) == set(range(1, 13))
+
+    def test_each_month_has_24_hours(self):
+        for month, table in CLIMB_BY_MONTH.items():
+            assert len(table) == 24, f"month {month} has {len(table)} hour entries, expected 24"
+
+    def test_hour_zero_has_high_climb(self):
+        """Midnight has the most rise still ahead."""
+        for month in range(1, 13):
+            assert CLIMB_BY_MONTH[month][0] > 0
+
+    def test_hour_19_and_later_are_zero(self):
+        """After 7pm no further rise is expected."""
+        for month in range(1, 13):
+            for hour in range(19, 24):
+                assert CLIMB_BY_MONTH[month][hour] == 0.0, (
+                    f"month {month} hour {hour} should be 0.0"
+                )
+
+
+class TestExpectedAdditionalRise:
+    def _dt(self, month: int, hour: int) -> datetime:
+        return datetime(2026, month, 1, hour, 0)
+
+    def test_may_hour_14_returns_4_5(self):
+        result = expected_additional_rise(self._dt(5, 14))
+        assert result == 4.5
+
+    def test_may_hour_0_returns_22(self):
+        result = expected_additional_rise(self._dt(5, 0))
+        assert result == 22.0
+
+    def test_hour_19_returns_zero(self):
+        result = expected_additional_rise(self._dt(5, 19))
+        assert result == 0.0
+
+    def test_all_months_return_same_may_values(self):
+        """All months currently use May as placeholder — values must match."""
+        for month in range(1, 13):
+            result = expected_additional_rise(self._dt(month, 10))
+            assert result == 8.0, f"month {month} hour 10: expected 8.0, got {result}"
+
+    def test_returns_float(self):
+        result = expected_additional_rise(self._dt(7, 12))
+        assert isinstance(result, float)

--- a/src/tests/test_envelope.py
+++ b/src/tests/test_envelope.py
@@ -1,0 +1,214 @@
+"""Unit tests for src/model/envelope.py — pure math functions, no API calls.
+
+Ported from archive/polymarket-spike/tests/test_envelope.py with imports
+updated to use src.model.envelope (src.model.climb_rates provides climb rates).
+"""
+from datetime import datetime
+from math import isclose
+
+import pytest
+
+from src.model.envelope import (
+    Bracket,
+    WeatherState,
+    compute_envelope,
+    p_normal_between,
+    true_probability_yes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_state(
+    current_high_f: float = 80.0,
+    latest_temp_f: float = 80.0,
+    forecast_high_f: float | None = 81.0,
+    hour: int = 14,
+    station: str = "KNYC",
+) -> WeatherState:
+    """Build a WeatherState with sensible defaults for testing."""
+    now = datetime(2026, 5, 15, hour, 30)
+    return WeatherState(
+        station=station,
+        now_local=now,
+        sunset_local=datetime(2026, 5, 15, 20, 15),
+        current_high_f=current_high_f,
+        current_high_time=now,
+        latest_temp_f=latest_temp_f,
+        latest_temp_time=now,
+        forecast_high_f=forecast_high_f,
+    )
+
+
+def make_bracket(
+    low_f: float,
+    high_f: float,
+    yes_ask_cents: int = 50,
+    no_ask_cents: int = 52,
+) -> Bracket:
+    return Bracket(
+        ticker="TEST-TICKER",
+        low_f=low_f,
+        high_f=high_f,
+        yes_ask_cents=yes_ask_cents,
+        yes_ask_size=100,
+        no_ask_cents=no_ask_cents,
+        no_ask_size=100,
+    )
+
+
+# ---------------------------------------------------------------------------
+# p_normal_between
+# ---------------------------------------------------------------------------
+
+class TestPNormalBetween:
+    def test_known_value_symmetric_interval(self):
+        """P(80 <= X <= 82) where X~N(81, 2^2) ≈ 0.3829."""
+        result = p_normal_between(80.0, 82.0, mean=81.0, stddev=2.0)
+        assert isclose(result, 0.3829, abs_tol=0.001), f"Got {result}"
+
+    def test_wide_interval_near_one(self):
+        result = p_normal_between(-100.0, 100.0, mean=50.0, stddev=5.0)
+        assert result > 0.9999
+
+    def test_interval_far_from_mean_near_zero(self):
+        result = p_normal_between(200.0, 210.0, mean=80.0, stddev=2.0)
+        assert result < 1e-6
+
+    def test_clamps_to_zero(self):
+        result = p_normal_between(100.0, 90.0, mean=80.0, stddev=2.0)
+        assert result == 0.0
+
+    def test_clamps_to_one(self):
+        result = p_normal_between(-1000.0, 1000.0, mean=0.0, stddev=1.0)
+        assert result == 1.0
+
+    def test_symmetric_around_mean(self):
+        mean, d, stddev = 75.0, 3.0, 2.0
+        left = p_normal_between(mean - d, mean, mean=mean, stddev=stddev)
+        right = p_normal_between(mean, mean + d, mean=mean, stddev=stddev)
+        assert isclose(left, right, abs_tol=1e-10)
+
+    def test_point_interval_near_zero(self):
+        result = p_normal_between(81.0, 81.0, mean=81.0, stddev=2.0)
+        assert result == 0.0
+
+    def test_known_value_one_sigma(self):
+        """P(mean - sigma <= X <= mean + sigma) ≈ 0.6827."""
+        mean, stddev = 80.0, 3.0
+        result = p_normal_between(mean - stddev, mean + stddev, mean=mean, stddev=stddev)
+        assert isclose(result, 0.6827, abs_tol=0.001), f"Got {result}"
+
+
+# ---------------------------------------------------------------------------
+# compute_envelope — climb_rates values (May): hour14=4.5, hour12=6, hour21=0, hour15=3.5
+# ---------------------------------------------------------------------------
+
+class TestComputeEnvelope:
+    def test_min_high_equals_current_high(self):
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        min_high, _ = compute_envelope(state)
+        assert min_high == 82.0
+
+    def test_max_high_gte_current_high(self):
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        _, max_high = compute_envelope(state)
+        assert max_high >= 82.0
+
+    def test_max_high_uses_climb_from_latest_temp(self):
+        """hour=14, climb=4.5: max = max(82, 80+4.5) = 84.5."""
+        state = make_state(current_high_f=82.0, latest_temp_f=80.0, hour=14)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 82.0
+        assert max_high == 84.5
+
+    def test_max_high_when_latest_temp_above_high(self):
+        """hour=12, climb=6: max = max(85, 85+6) = 91."""
+        state = make_state(current_high_f=85.0, latest_temp_f=85.0, hour=12)
+        _, max_high = compute_envelope(state)
+        assert max_high == 91.0
+
+    def test_no_rise_after_hour_20(self):
+        """After 8pm, expected additional rise is 0."""
+        state = make_state(current_high_f=88.0, latest_temp_f=88.0, hour=21)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 88.0
+        assert max_high == 88.0
+
+    def test_envelope_bounds_when_latest_temp_lower(self):
+        """hour=15, climb=3.5: max = max(85, 79+3.5) = max(85, 82.5) = 85."""
+        state = make_state(current_high_f=85.0, latest_temp_f=79.0, hour=15)
+        min_high, max_high = compute_envelope(state)
+        assert min_high == 85.0
+        assert max_high == 85.0
+
+    def test_minutes_to_settlement_optional(self):
+        """compute_envelope must accept zero positional arguments beyond state."""
+        state = make_state(current_high_f=80.0, latest_temp_f=80.0, hour=14)
+        result = compute_envelope(state)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# true_probability_yes
+# ---------------------------------------------------------------------------
+
+class TestTrueProbabilityYes:
+    def test_bracket_below_current_high_returns_zero(self):
+        state = make_state(current_high_f=85.0, latest_temp_f=83.0, hour=15)
+        bracket = make_bracket(low_f=78.0, high_f=84.0)
+        assert true_probability_yes(bracket, state) == 0.0
+
+    def test_bracket_above_envelope_returns_zero(self):
+        state = make_state(current_high_f=85.0, latest_temp_f=85.0, hour=21)
+        bracket = make_bracket(low_f=90.0, high_f=95.0)
+        assert true_probability_yes(bracket, state) == 0.0
+
+    def test_bracket_contains_full_envelope_returns_one(self):
+        state = make_state(current_high_f=82.0, latest_temp_f=82.0, hour=21)
+        bracket = make_bracket(low_f=70.0, high_f=90.0)
+        assert true_probability_yes(bracket, state) == 1.0
+
+    def test_exact_envelope_bracket_returns_one(self):
+        state = make_state(current_high_f=82.0, latest_temp_f=82.0, hour=21)
+        bracket = make_bracket(low_f=82.0, high_f=82.0)
+        assert true_probability_yes(bracket, state) == 1.0
+
+    def test_bayesian_case_uses_forecast(self):
+        """Partial bracket in mid-day uncertainty window returns 0 < p < 1."""
+        # hour=14, climb=4.5; max_env = max(80, 79+4.5) = 83.5
+        # bracket [81, 85]: lo(81) > current_high(80) but lo < max_env(83.5)
+        state = make_state(current_high_f=80.0, latest_temp_f=79.0, hour=14, forecast_high_f=82.0)
+        bracket = make_bracket(low_f=81.0, high_f=85.0)
+        result = true_probability_yes(bracket, state)
+        assert 0.0 < result < 1.0
+
+    def test_no_forecast_falls_back_to_midpoint(self):
+        """With no forecast, bracket containing full envelope returns 1.0."""
+        state = make_state(current_high_f=80.0, latest_temp_f=79.0, hour=14, forecast_high_f=None)
+        bracket = make_bracket(low_f=80.0, high_f=84.0)
+        result = true_probability_yes(bracket, state)
+        assert result == 1.0
+
+    def test_high_confidence_no_side(self):
+        """Bracket far above max envelope returns 0.0."""
+        state = make_state(current_high_f=79.0, latest_temp_f=78.0, hour=14, forecast_high_f=80.0)
+        bracket = make_bracket(low_f=95.0, high_f=100.0)
+        result = true_probability_yes(bracket, state)
+        assert result == 0.0
+
+    def test_probability_bounded_zero_to_one(self):
+        state = make_state(current_high_f=82.0, latest_temp_f=81.0, hour=13, forecast_high_f=84.0)
+        for lo, hi in [(70, 75), (80, 85), (85, 90), (100, 110)]:
+            bracket = make_bracket(low_f=float(lo), high_f=float(hi))
+            result = true_probability_yes(bracket, state)
+            assert 0.0 <= result <= 1.0, f"Out of bounds for [{lo}, {hi}]: {result}"
+
+    def test_minutes_to_settlement_optional(self):
+        """true_probability_yes must work with just bracket and state."""
+        state = make_state(current_high_f=80.0, latest_temp_f=80.0, hour=14, forecast_high_f=82.0)
+        bracket = make_bracket(low_f=79.0, high_f=85.0)
+        result = true_probability_yes(bracket, state)
+        assert 0.0 <= result <= 1.0


### PR DESCRIPTION
## Summary

Creates the Polymarket API client and the weather model modules for Epic 0.

- `src/data/polymarket.py`: Promoted from archive `polymarket_client.py`; all HTTP via `http_client` (`cached_fetch_json` for market list at 5-min TTL per page, `fetch` for live orderbook which must not be cached)
- `src/model/climb_rates.py`: New module with monthly climb rate tables; `expected_additional_rise(now_local)` keyed by month for future per-city expansion (Epic 5, E5-3)
- `src/model/envelope.py`: Promoted from `src/improved_envelope.py`; `fetch_secondary_forecast` removed (lives in `data/open_meteo.py`); `minutes_to_settlement` made optional with default `9999.0` in both `compute_envelope` and `true_probability_yes`
- `src/improved_envelope.py` deleted (code fully promoted)
- 34 new unit tests covering both modules

Closes #37
Closes #38

## How to test

```python
# Imports
python -c "
from src.data.polymarket import get_weather_markets, get_orderbook
from src.model.envelope import WeatherState, Bracket, true_probability_yes, compute_envelope
from src.model.climb_rates import CLIMB_BY_MONTH, expected_additional_rise
print('All imports OK')
print(f'Climb months: {len(CLIMB_BY_MONTH)}')
"

# Run tests
python -m pytest src/tests/test_climb_rates.py src/tests/test_envelope.py -v

# Live market fetch (requires network)
python -c "
from src.data.polymarket import get_weather_markets
markets = get_weather_markets()
print(f'Markets: {len(markets)}')
markets2 = get_weather_markets()  # Should hit cache
"
```