### PR TITLE
E0-9: Add unit tests for scanner and fee modules

### DIFF
--- a/src/tests/test_fee.py
+++ b/src/tests/test_fee.py
@@ -1,0 +1,35 @@
+"""Unit tests for src/strategy/fee.py."""
+import pytest
+from src.strategy.fee import estimate_fee_cents
+
+
+class TestEstimateFeeCents:
+    """Tests for the Polymarket taker fee approximation."""
+
+    def test_fee_at_fifty_cents_is_max(self):
+        """50¢ price gives the maximum fee (0.07 * 0.5 * 0.5 = 1.75¢)."""
+        fee = estimate_fee_cents(50)
+        assert abs(fee - 1.75) < 0.01
+
+    def test_fee_at_one_cent_floors_to_one(self):
+        """1¢ price gives minimum fee (floored at 1.0¢)."""
+        fee = estimate_fee_cents(1)
+        assert fee == pytest.approx(1.0)
+
+    def test_fee_at_ninety_nine_cents_floors_to_one(self):
+        """99¢ price gives minimum fee (floored at 1.0¢)."""
+        fee = estimate_fee_cents(99)
+        assert fee == pytest.approx(1.0, abs=0.1)
+
+    def test_fee_is_symmetric(self):
+        """Fee at price p equals fee at price (100-p) by symmetry."""
+        assert abs(estimate_fee_cents(30) - estimate_fee_cents(70)) < 0.001
+
+    def test_fee_always_at_least_one_cent(self):
+        """Fee is always >= 1¢ for any valid price."""
+        for price in range(1, 100):
+            assert estimate_fee_cents(price) >= 1.0
+
+    def test_fee_midpoint_greater_than_floor(self):
+        """Fee at 50¢ must be greater than the 1¢ floor."""
+        assert estimate_fee_cents(50) > 1.0

--- a/src/tests/test_scanner.py
+++ b/src/tests/test_scanner.py
@@ -1,0 +1,123 @@
+"""Unit tests for src/strategy/scanner.py — bracket parsing and market scanning."""
+import pytest
+from src.strategy.scanner import parse_bracket_from_market, scan_markets, is_highest_temp_market
+
+
+def _market(group_title: str, question: str = "", condition_id: str = "0xabc") -> dict:
+    """Build a minimal market dict matching Polymarket's Gamma API shape."""
+    return {
+        "conditionId": condition_id,
+        "question": question,
+        "groupItemTitle": group_title,
+        "outcomes": '["Yes","No"]',
+        "outcomePrices": '["0.60","0.40"]',
+        "clobTokenIds": '["tok_yes","tok_no"]',
+    }
+
+
+class TestParseBracketFromMarket:
+    """Tests for all 4 bracket label formats that Polymarket uses."""
+
+    def test_lte_or_below(self):
+        """'55°F or below' → low=-50, high=55."""
+        b = parse_bracket_from_market(_market("55°F or below"))
+        assert b is not None
+        assert b.low_f == -50.0
+        assert b.high_f == 55.0
+
+    def test_lte_or_less(self):
+        """'60°F or less' → low=-50, high=60."""
+        b = parse_bracket_from_market(_market("60°F or less"))
+        assert b is not None
+        assert b.high_f == 60.0
+
+    def test_gte_or_above(self):
+        """'92°F or above' → low=92, high=200."""
+        b = parse_bracket_from_market(_market("92°F or above"))
+        assert b is not None
+        assert b.low_f == 92.0
+        assert b.high_f == 200.0
+
+    def test_gte_or_more(self):
+        """'85°F or more' → low=85, high=200."""
+        b = parse_bracket_from_market(_market("85°F or more"))
+        assert b is not None
+        assert b.low_f == 85.0
+
+    def test_between_and(self):
+        """'between 56 and 57°F' → low=56, high=57."""
+        b = parse_bracket_from_market(_market("between 56 and 57°F"))
+        assert b is not None
+        assert b.low_f == 56.0
+        assert b.high_f == 57.0
+
+    def test_range_dash(self):
+        """'58-60°F' → low=58, high=60."""
+        b = parse_bracket_from_market(_market("58-60°F"))
+        assert b is not None
+        assert b.low_f == 58.0
+        assert b.high_f == 60.0
+
+    def test_range_em_dash(self):
+        """'82–84°F' (em-dash) → low=82, high=84."""
+        b = parse_bracket_from_market(_market("82–84°F"))
+        assert b is not None
+        assert b.low_f == 82.0
+        assert b.high_f == 84.0
+
+    def test_unparseable_returns_none(self):
+        """Unrecognized label returns None."""
+        b = parse_bracket_from_market(_market("something completely unexpected 999xyz"))
+        assert b is None
+
+    def test_missing_condition_id_returns_none(self):
+        """Market without conditionId returns None."""
+        market = {"question": "will it rain?", "groupItemTitle": "58-60°F"}
+        b = parse_bracket_from_market(market)
+        assert b is None
+
+    def test_yes_price_parsed(self):
+        """YES price is correctly extracted from outcomePrices."""
+        b = parse_bracket_from_market(_market("58-60°F"))
+        assert b is not None
+        assert b.yes_ask_cents == 60  # 0.60 * 100
+
+
+class TestScanMarkets:
+    """Tests for scan_markets() function."""
+
+    def test_empty_inputs_return_empty(self):
+        """scan_markets with no weather and no markets returns empty lists."""
+        candidates, snapshots = scan_markets({}, [])
+        assert candidates == []
+        assert snapshots == []
+
+    def test_no_matching_markets(self):
+        """Markets that don't match any station return no candidates."""
+        market = _market("58-60°F", question="Will the highest temperature in Unknown City be 58-60°F?")
+        candidates, snapshots = scan_markets({}, [market])
+        assert candidates == []
+        assert snapshots == []
+
+
+class TestIsHighestTempMarket:
+    """Tests for is_highest_temp_market() filter."""
+
+    def test_matching_city(self):
+        """Correctly identifies a Miami highest-temp market."""
+        market = {"question": "Will the highest temperature in Miami be 85-87°F?"}
+        is_temp, station = is_highest_temp_market(market)
+        assert is_temp is True
+        assert station == "KMIA"
+
+    def test_lowest_temp_skipped(self):
+        """Lowest-temperature markets must NOT match."""
+        market = {"question": "Will the lowest temperature in Miami be 70°F?"}
+        is_temp, _ = is_highest_temp_market(market)
+        assert is_temp is False
+
+    def test_unknown_city_returns_false(self):
+        """Unknown city returns False."""
+        market = {"question": "Will the highest temperature in Unknown City be 80°F?"}
+        is_temp, _ = is_highest_temp_market(market)
+        assert is_temp is False


### PR DESCRIPTION
## Summary
Adds missing unit test files for the strategy layer, completing Epic 0 test coverage.

- `src/tests/test_scanner.py`: 15 tests — bracket parsing (all 4 Polymarket label formats), scan_markets smoke tests, is_highest_temp_market filter
- `src/tests/test_fee.py`: 6 tests — fee floor, fee symmetry, fee at midpoint

Note: test_envelope.py (24 tests) and test_climb_rates.py (10 tests) already existed — not duplicated.

## Test results
```
pytest src/tests/ -q
# Result: 55 passed (10 existing + 24 existing + 15 new + 6 new)
```

Closes #41