### PR TITLE
E0-8: Add src/scripts/run.py and src/scripts/settle.py

### DIFF
--- a/src/scripts/run.py
+++ b/src/scripts/run.py
@@ -1,0 +1,215 @@
+"""Main polling loop. Run during trading hours.
+
+Usage:
+    python src/scripts/run.py --paper         # paper trading mode (default)
+    python src/scripts/run.py --paper --once  # single poll then exit
+"""
+import argparse
+import csv
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.config import (
+    STATIONS, STATION_TZ, POLL_INTERVAL_SECONDS, LOG_DIR,
+    CANDIDATES_CSV, SNAPSHOTS_JSONL,
+)
+from src.data.metar import fetch_all_metars_today, compute_daily_high, now_local, sunset_local
+from src.data.nws import fetch_nws_forecast_high
+from src.data.open_meteo import fetch_secondary_forecast
+from src.data.polymarket import get_weather_markets
+from src.model.envelope import WeatherState
+from src.strategy.scanner import scan_markets
+
+
+# ---------------------------------------------------------------------------
+# Risk management stub — replaced by src/risk/manager.py in Epic 1
+# ---------------------------------------------------------------------------
+
+class _RiskManagerStub:
+    """Placeholder: allows all trades. Replace with RiskManager from E1-1."""
+    def allow_trade(self, *args, **kwargs) -> tuple[bool, str]:
+        return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+def _append_snapshot(snap: dict) -> None:
+    LOG_DIR.mkdir(exist_ok=True)
+    with open(SNAPSHOTS_JSONL, "a") as f:
+        f.write(json.dumps(snap, default=str) + "\n")
+
+
+def _append_candidate(row: dict) -> None:
+    LOG_DIR.mkdir(exist_ok=True)
+    new_file = not CANDIDATES_CSV.exists()
+    with open(CANDIDATES_CSV, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if new_file:
+            w.writeheader()
+        w.writerow(row)
+
+
+# ---------------------------------------------------------------------------
+# Poll loop
+# ---------------------------------------------------------------------------
+
+def poll_once(risk_manager) -> None:
+    """Run one full poll: build weather states, fetch markets, scan, log candidates."""
+    ts = datetime.now(timezone.utc).isoformat()
+    print(f"\n=== Poll at {ts} ===")
+
+    # 1. Build weather state for each station
+    weather: dict[str, WeatherState] = {}
+    for station, lat, lon, city, _ in STATIONS:
+        metars = fetch_all_metars_today(station)
+        if not metars:
+            print(f"[{station}] no METAR data, skipping")
+            continue
+
+        result = compute_daily_high(metars, STATION_TZ[station])
+        if not result:
+            print(f"[{station}] could not compute daily high, skipping")
+            continue
+        high_f, high_time = result
+
+        latest = metars[0]
+        latest_temp_c = latest.get("temp")
+        if latest_temp_c is None:
+            print(f"[{station}] latest METAR missing temp, skipping")
+            continue
+
+        obs_str = latest.get("reportTime") or latest.get("obsTime")
+        if not obs_str:
+            print(f"[{station}] latest METAR missing time, skipping")
+            continue
+
+        try:
+            from dateutil import parser as dtparse
+            latest_temp_f = (float(latest_temp_c) * 9 / 5) + 32
+            latest_time = dtparse.parse(obs_str)
+            if latest_time.tzinfo is None:
+                latest_time = latest_time.replace(tzinfo=timezone.utc)
+        except Exception as e:
+            print(f"[{station}] METAR parse error: {e}, skipping")
+            continue
+
+        forecast_nws = fetch_nws_forecast_high(lat, lon)
+        forecast_secondary = fetch_secondary_forecast(lat, lon)
+
+        weather[station] = WeatherState(
+            station=station,
+            now_local=now_local(station),
+            sunset_local=sunset_local(station, lat, lon),
+            current_high_f=high_f,
+            current_high_time=high_time,
+            latest_temp_f=latest_temp_f,
+            latest_temp_time=latest_time,
+            forecast_high_f=forecast_nws,
+            secondary_forecast_f=forecast_secondary,
+        )
+        print(f"[{station}] high={high_f:.1f}°F latest={latest_temp_f:.1f}°F nws={forecast_nws}")
+
+    if not weather:
+        print("[run] No weather data for any station — skipping market scan")
+        return
+
+    # 2. Fetch Polymarket markets
+    try:
+        markets = get_weather_markets()
+    except Exception as e:
+        print(f"[polymarket] error: {e} — skipping this poll")
+        return
+    print(f"[polymarket] {len(markets)} weather markets fetched")
+
+    # 3. Scan for candidates
+    candidates, snapshots = scan_markets(weather, markets)
+
+    # 4. Log all snapshots
+    for snap in snapshots:
+        _append_snapshot(snap)
+
+    # 5. Process candidates
+    n_flagged = 0
+    for cand in candidates:
+        allowed, reason = risk_manager.allow_trade()
+        if not allowed:
+            print(f"  [risk] BLOCKED {cand.bracket.ticker[:16]}… {cand.side}: {reason}")
+            continue
+
+        n_flagged += 1
+        row = {
+            "ts": ts,
+            "station": cand.station,
+            "ticker": cand.bracket.ticker,
+            "bracket_low": cand.bracket.low_f,
+            "bracket_high": cand.bracket.high_f,
+            "yes_ask": cand.bracket.yes_ask_cents,
+            "no_ask": cand.bracket.no_ask_cents,
+            "p_yes": round(cand.p_yes, 4),
+            "ev_yes": round(cand.ev_yes, 2),
+            "ev_no": round(cand.ev_no, 2),
+            "flagged_side": cand.side,
+            "flagged_edge": round(cand.edge_cents, 2),
+            "flagged_price": cand.price_cents,
+            "flagged_confidence": round(cand.confidence, 4),
+            "minutes_to_settlement": round(cand.minutes_to_settlement, 1),
+        }
+        _append_candidate(row)
+
+    print(
+        f"[scan] {len(markets)} markets, {len(snapshots)} evaluated, "
+        f"{len(candidates)} candidates, {n_flagged} logged"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MeteoEdge polling loop")
+    parser.add_argument(
+        "--paper", action="store_true", default=True,
+        help="Paper trading mode (default; no real orders placed)",
+    )
+    parser.add_argument(
+        "--once", action="store_true", default=False,
+        help="Run a single poll then exit (for testing)",
+    )
+    parser.add_argument(
+        "--live", action="store_true", default=False,
+        help="LIVE trading mode — NOT YET IMPLEMENTED (see E3-2)",
+    )
+    args = parser.parse_args()
+
+    if args.live:
+        raise NotImplementedError(
+            "Live trading not yet implemented — see Epic 3, issue E3-2. "
+            "Run with --paper for paper trading."
+        )
+
+    mode = "PAPER" if args.paper else "LIVE"
+    print(f"MeteoEdge starting in {mode} mode.")
+    print("Logs will be written to ./logs/")
+
+    risk_manager = _RiskManagerStub()
+
+    if args.once:
+        poll_once(risk_manager)
+        print("[run] --once mode: exiting after single poll.")
+        return
+
+    print(f"Polling every {POLL_INTERVAL_SECONDS}s. Press Ctrl-C to stop.")
+    while True:
+        try:
+            poll_once(risk_manager)
+        except KeyboardInterrupt:
+            print("\n[run] Stopping.")
+            break
+        except Exception as e:
+            print(f"[run] Unhandled error in poll: {e}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/settle.py
+++ b/src/scripts/settle.py
@@ -1,0 +1,99 @@
+"""Run once a day after NWS publishes the Daily Climate Report (typically ~9am local next day)."""
+import csv
+from datetime import date, timedelta
+
+from src.config import STATIONS, LOG_DIR, CANDIDATES_CSV, SETTLEMENTS_CSV, STATION_TZ
+from src.http_client import fetch
+
+
+def fetch_daily_climate_high(station: str, target_date: date) -> float | None:
+    """
+    Pull the actual daily high for a station on target_date using 48h METAR history.
+    The spike uses METAR as a ground-truth proxy; the full build should cross-check
+    against the NWS Daily Climate Report.
+    """
+    url = f"https://aviationweather.gov/api/data/metar?ids={station}&format=json&hours=48"
+    try:
+        r = fetch(url, timeout=20)
+        r.raise_for_status()
+        data = r.json() or []
+    except Exception as e:
+        print(f"[settle] {station} error: {e}")
+        return None
+
+    import pytz
+    from dateutil import parser as dtparse
+    tz = pytz.timezone(STATION_TZ[station])
+    best = None
+    for m in data:
+        temp_c = m.get("temp")
+        obs = m.get("reportTime") or m.get("obsTime")
+        if temp_c is None or obs is None:
+            continue
+        try:
+            t = dtparse.parse(obs)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=pytz.UTC)
+            if t.astimezone(tz).date() != target_date:
+                continue
+            temp_f = (float(temp_c) * 9 / 5) + 32
+            if best is None or temp_f > best:
+                best = temp_f
+        except Exception:
+            continue
+    return best
+
+
+def settle_yesterday():
+    """For each candidate from yesterday, record whether it would have won."""
+    if not CANDIDATES_CSV.exists():
+        print("No candidates to settle.")
+        return
+
+    yesterday = date.today() - timedelta(days=1)
+    print(f"Settling for {yesterday}")
+
+    truth = {}
+    for station, _, _, _, _ in STATIONS:
+        h = fetch_daily_climate_high(station, yesterday)
+        if h is not None:
+            truth[station] = h
+            print(f"  {station} daily high = {h:.1f}°F")
+
+    new_file = not SETTLEMENTS_CSV.exists()
+    with open(CANDIDATES_CSV) as f_in, open(SETTLEMENTS_CSV, "a", newline="") as f_out:
+        reader = csv.DictReader(f_in)
+        writer = None
+        for row in reader:
+            ts = row["ts"][:10]
+            if ts != yesterday.isoformat():
+                continue
+            station = row["station"]
+            if station not in truth:
+                continue
+            actual = truth[station]
+            lo, hi = float(row["bracket_low"]), float(row["bracket_high"])
+            yes_won = lo <= actual <= hi
+            won = yes_won if row["flagged_side"] == "YES" else not yes_won
+
+            if row["flagged_side"] == "YES":
+                pnl = (100 - float(row["flagged_price"])) if yes_won else -float(row["flagged_price"])
+            else:
+                pnl = (100 - float(row["flagged_price"])) if (not yes_won) else -float(row["flagged_price"])
+
+            out = {**row, "actual_high": actual, "yes_won": yes_won,
+                   "candidate_won": won, "pnl_cents": round(pnl, 2)}
+            if writer is None:
+                writer = csv.DictWriter(f_out, fieldnames=list(out.keys()))
+                if new_file:
+                    writer.writeheader()
+            writer.writerow(out)
+
+    if writer is not None:
+        print(f"Wrote settlements to {SETTLEMENTS_CSV}")
+    else:
+        print(f"No candidates matched {yesterday} in {CANDIDATES_CSV} — nothing written.")
+
+
+if __name__ == "__main__":
+    settle_yesterday()


### PR DESCRIPTION
## Summary

Creates the two entry-point scripts for Epic 0 (closes #40).

- `src/scripts/run.py`: Main polling loop — builds weather states for each configured station, fetches Polymarket weather markets, scans for candidates via `scan_markets`, and logs snapshots to `logs/snapshots.jsonl` and candidates to `logs/candidates.csv`. `--paper` is the default mode (no real orders). `--once` flag runs a single poll and exits. `--live` raises `NotImplementedError` (see E3-2).
- `src/scripts/settle.py`: Promoted from `archive/polymarket-spike/settle.py`; imports updated to `src.config` and `src.http_client.fetch` (replacing bare `httpx.get`), `STATION_TZ` import moved from spike to src.config.
- `_RiskManagerStub` in run.py: allows all trades until E1-1 (RiskManager) is implemented.

Closes #40

## How to test

```bash
# Import checks (no network needed)
python -c "import src.scripts.run, src.scripts.settle; print('imports OK')"

# Single live poll (hits real APIs, ~30-60s due to NWS rate limiting)
python src/scripts/run.py --once
```