### PR TITLE
E1-1: Implement src/risk/manager.py

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -50,6 +50,13 @@ MIN_MINUTES_TO_SETTLEMENT = 15
 # Polling cadence (env var override)
 POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "300"))  # 5 minutes default
 
+# Risk management limits (all configurable via env vars)
+STARTING_CAPITAL_EUR = float(os.getenv("STARTING_CAPITAL_EUR", "500.0"))
+RISK_DAILY_LOSS_LIMIT_EUR = float(os.getenv("RISK_DAILY_LOSS_LIMIT_EUR", "50.0"))
+RISK_MAX_OPEN_POSITIONS = int(os.getenv("RISK_MAX_OPEN_POSITIONS", "15"))
+RISK_DRAWDOWN_STOP_PCT = float(os.getenv("RISK_DRAWDOWN_STOP_PCT", "0.15"))
+RISK_MIN_LIQUIDITY = int(os.getenv("RISK_MIN_LIQUIDITY", "50"))
+
 # Historical climb rates: p95 additional rise (°F) from time-of-day to end-of-day.
 # Hand-seeded approximations. In the full build, compute from 5 years of METAR.
 # Hours 0-9 reflect the full diurnal range still ahead (daily min typically 4-7am).

--- a/src/risk/manager.py
+++ b/src/risk/manager.py
@@ -1,0 +1,122 @@
+"""Risk manager — gates every trade before execution.
+
+All limits are read from src/config.py and can be overridden via environment
+variables. State is held in memory and resets daily at midnight UTC; it is
+not persisted across process restarts (acceptable for the paper-trading phase).
+"""
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+
+from src.config import (
+    RISK_DAILY_LOSS_LIMIT_EUR,
+    RISK_DRAWDOWN_STOP_PCT,
+    RISK_MAX_OPEN_POSITIONS,
+    RISK_MIN_LIQUIDITY,
+    STARTING_CAPITAL_EUR,
+)
+
+
+@dataclass
+class RiskManager:
+    """Gates trade execution against daily-loss, position, drawdown, and liquidity limits.
+
+    Parameters are loaded from config.py defaults so that a plain
+    ``RiskManager()`` always uses the values set via environment variables.
+
+    Usage::
+
+        rm = RiskManager()
+        ok, reason = rm.allow_trade(capital=current_capital, liquidity_contracts=200)
+        if not ok:
+            print(f"Trade blocked: {reason}")
+            return
+
+        rm.open_position()
+        # … execute trade …
+        rm.close_position()
+        rm.record_pnl(pnl_eur)
+    """
+
+    daily_loss_limit_eur: float = field(default_factory=lambda: RISK_DAILY_LOSS_LIMIT_EUR)
+    max_open_positions: int = field(default_factory=lambda: RISK_MAX_OPEN_POSITIONS)
+    drawdown_stop_pct: float = field(default_factory=lambda: RISK_DRAWDOWN_STOP_PCT)
+    min_market_liquidity: int = field(default_factory=lambda: RISK_MIN_LIQUIDITY)
+    starting_capital: float = field(default_factory=lambda: STARTING_CAPITAL_EUR)
+
+    # Internal state — reset daily at midnight UTC
+    _daily_pnl: float = field(default=0.0, init=False, repr=False)
+    _open_positions: int = field(default=0, init=False, repr=False)
+    _trade_day: date = field(
+        default_factory=lambda: datetime.now(timezone.utc).date(),
+        init=False,
+        repr=False,
+    )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _reset_if_new_day(self) -> None:
+        """Reset daily PnL accumulator when the UTC calendar day has rolled over."""
+        today = datetime.now(timezone.utc).date()
+        if today != self._trade_day:
+            self._daily_pnl = 0.0
+            self._trade_day = today
+
+    # ------------------------------------------------------------------
+    # State mutators
+    # ------------------------------------------------------------------
+
+    def record_pnl(self, pnl_eur: float) -> None:
+        """Accumulate realised PnL for the current trading day.
+
+        Call this after every trade closes (whether profitable or not).
+        """
+        self._reset_if_new_day()
+        self._daily_pnl += pnl_eur
+
+    def open_position(self) -> None:
+        """Increment the open-position counter when a trade is entered."""
+        self._open_positions += 1
+
+    def close_position(self) -> None:
+        """Decrement the open-position counter when a trade is exited."""
+        self._open_positions = max(0, self._open_positions - 1)
+
+    # ------------------------------------------------------------------
+    # Trade gate
+    # ------------------------------------------------------------------
+
+    def allow_trade(
+        self,
+        capital: float,
+        liquidity_contracts: int = 9999,
+    ) -> tuple[bool, str]:
+        """Determine whether a new trade is permitted under current risk limits.
+
+        Args:
+            capital: Current portfolio value in EUR.
+            liquidity_contracts: Combined yes_ask_size + no_ask_size for the
+                target market. Defaults to a large value so callers that do not
+                track liquidity are not accidentally blocked.
+
+        Returns:
+            ``(True, "")`` when all limits are clear.
+            ``(False, reason)`` with a human-readable explanation when blocked.
+        """
+        self._reset_if_new_day()
+
+        if self._daily_pnl <= -self.daily_loss_limit_eur:
+            return False, f"daily loss limit hit (€{self._daily_pnl:.2f})"
+
+        if self._open_positions >= self.max_open_positions:
+            return False, f"max open positions ({self.max_open_positions}) reached"
+
+        drawdown = (self.starting_capital - capital) / self.starting_capital
+        if drawdown >= self.drawdown_stop_pct:
+            return False, f"drawdown stop triggered ({drawdown:.1%})"
+
+        if liquidity_contracts < self.min_market_liquidity:
+            return False, f"insufficient liquidity ({liquidity_contracts} < {self.min_market_liquidity})"
+
+        return True, ""

--- a/src/tests/test_risk.py
+++ b/src/tests/test_risk.py
@@ -1,0 +1,276 @@
+"""Unit tests for src/risk/manager.py.
+
+Each of the 4 block conditions is tested in isolation by directly setting
+the relevant internal state before calling allow_trade(). This avoids any
+reliance on clock mocking for the basic limit tests.
+"""
+import pytest
+from src.risk.manager import RiskManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rm(**kwargs) -> RiskManager:
+    """Create a RiskManager with explicit limits (no env-var side effects in tests)."""
+    defaults = dict(
+        daily_loss_limit_eur=50.0,
+        max_open_positions=15,
+        drawdown_stop_pct=0.15,
+        min_market_liquidity=50,
+        starting_capital=500.0,
+    )
+    defaults.update(kwargs)
+    return RiskManager(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Normal (allow) case
+# ---------------------------------------------------------------------------
+
+class TestAllowTradeNormalCase:
+    """allow_trade() returns (True, "") when all limits are clear."""
+
+    def test_all_clear_returns_true_and_empty_reason(self):
+        rm = _rm()
+        ok, reason = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is True
+        assert reason == ""
+
+    def test_allow_with_default_liquidity(self):
+        """Callers that omit liquidity_contracts should not be blocked."""
+        rm = _rm()
+        ok, reason = rm.allow_trade(capital=500.0)
+        assert ok is True
+        assert reason == ""
+
+    def test_allow_with_partial_loss_not_at_limit(self):
+        """PnL at -49 should still allow trades (limit is -50)."""
+        rm = _rm()
+        rm._daily_pnl = -49.0
+        ok, _ = rm.allow_trade(capital=451.0, liquidity_contracts=100)
+        assert ok is True
+
+    def test_allow_with_positions_below_max(self):
+        """14 open positions (limit 15) should still allow trades."""
+        rm = _rm()
+        rm._open_positions = 14
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Condition 1: Daily loss limit
+# ---------------------------------------------------------------------------
+
+class TestDailyLossLimit:
+    """Block when _daily_pnl <= -daily_loss_limit_eur."""
+
+    def test_blocks_when_loss_equals_limit(self):
+        rm = _rm(daily_loss_limit_eur=50.0)
+        rm._daily_pnl = -50.0
+        ok, reason = rm.allow_trade(capital=450.0, liquidity_contracts=100)
+        assert ok is False
+        assert "daily loss" in reason
+
+    def test_blocks_when_loss_exceeds_limit(self):
+        rm = _rm(daily_loss_limit_eur=50.0)
+        rm._daily_pnl = -75.0
+        ok, reason = rm.allow_trade(capital=425.0, liquidity_contracts=100)
+        assert ok is False
+        assert "daily loss" in reason
+
+    def test_reason_contains_actual_pnl(self):
+        rm = _rm(daily_loss_limit_eur=50.0)
+        rm._daily_pnl = -51.23
+        _, reason = rm.allow_trade(capital=448.77, liquidity_contracts=100)
+        assert "-51.23" in reason
+
+    def test_does_not_block_just_above_limit(self):
+        rm = _rm(daily_loss_limit_eur=50.0)
+        rm._daily_pnl = -49.99
+        ok, _ = rm.allow_trade(capital=450.01, liquidity_contracts=100)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Condition 2: Max open positions
+# ---------------------------------------------------------------------------
+
+class TestMaxOpenPositions:
+    """Block when _open_positions >= max_open_positions."""
+
+    def test_blocks_when_at_max(self):
+        rm = _rm(max_open_positions=15)
+        rm._open_positions = 15
+        ok, reason = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is False
+        assert "max open positions" in reason
+        assert "15" in reason
+
+    def test_blocks_when_above_max(self):
+        rm = _rm(max_open_positions=15)
+        rm._open_positions = 20
+        ok, reason = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is False
+        assert "max open positions" in reason
+
+    def test_does_not_block_one_below_max(self):
+        rm = _rm(max_open_positions=15)
+        rm._open_positions = 14
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is True
+
+    def test_open_position_increments_counter(self):
+        rm = _rm()
+        assert rm._open_positions == 0
+        rm.open_position()
+        assert rm._open_positions == 1
+
+    def test_close_position_decrements_counter(self):
+        rm = _rm()
+        rm._open_positions = 3
+        rm.close_position()
+        assert rm._open_positions == 2
+
+    def test_close_position_does_not_go_below_zero(self):
+        rm = _rm()
+        rm._open_positions = 0
+        rm.close_position()
+        assert rm._open_positions == 0
+
+
+# ---------------------------------------------------------------------------
+# Condition 3: Drawdown stop
+# ---------------------------------------------------------------------------
+
+class TestDrawdownStop:
+    """Block when (starting_capital - capital) / starting_capital >= drawdown_stop_pct."""
+
+    def test_blocks_at_exact_drawdown_threshold(self):
+        # starting_capital=500, drawdown_stop_pct=0.15 → stop at capital=425
+        rm = _rm(starting_capital=500.0, drawdown_stop_pct=0.15)
+        ok, reason = rm.allow_trade(capital=425.0, liquidity_contracts=100)
+        assert ok is False
+        assert "drawdown" in reason
+
+    def test_blocks_when_drawdown_exceeds_threshold(self):
+        rm = _rm(starting_capital=500.0, drawdown_stop_pct=0.15)
+        ok, reason = rm.allow_trade(capital=400.0, liquidity_contracts=100)
+        assert ok is False
+        assert "drawdown" in reason
+
+    def test_reason_contains_drawdown_percentage(self):
+        rm = _rm(starting_capital=500.0, drawdown_stop_pct=0.15)
+        _, reason = rm.allow_trade(capital=425.0, liquidity_contracts=100)
+        # reason should contain the drawdown formatted as a percentage, e.g. "15.0%"
+        assert "%" in reason
+
+    def test_does_not_block_just_above_threshold_capital(self):
+        # capital=425.01 → drawdown ≈ 14.998% < 15%
+        rm = _rm(starting_capital=500.0, drawdown_stop_pct=0.15)
+        ok, _ = rm.allow_trade(capital=425.01, liquidity_contracts=100)
+        assert ok is True
+
+    def test_no_drawdown_when_capital_equals_starting(self):
+        rm = _rm(starting_capital=500.0, drawdown_stop_pct=0.15)
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Condition 4: Minimum market liquidity
+# ---------------------------------------------------------------------------
+
+class TestMinMarketLiquidity:
+    """Block when liquidity_contracts < min_market_liquidity."""
+
+    def test_blocks_when_below_minimum(self):
+        rm = _rm(min_market_liquidity=50)
+        ok, reason = rm.allow_trade(capital=500.0, liquidity_contracts=49)
+        assert ok is False
+        assert "liquidity" in reason
+        assert "49" in reason
+
+    def test_blocks_at_zero_liquidity(self):
+        rm = _rm(min_market_liquidity=50)
+        ok, reason = rm.allow_trade(capital=500.0, liquidity_contracts=0)
+        assert ok is False
+        assert "liquidity" in reason
+
+    def test_does_not_block_at_exact_minimum(self):
+        rm = _rm(min_market_liquidity=50)
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=50)
+        assert ok is True
+
+    def test_does_not_block_above_minimum(self):
+        rm = _rm(min_market_liquidity=50)
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=500)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# record_pnl
+# ---------------------------------------------------------------------------
+
+class TestRecordPnl:
+    """record_pnl accumulates realised PnL within the same day."""
+
+    def test_positive_pnl_accumulates(self):
+        rm = _rm()
+        rm.record_pnl(10.0)
+        rm.record_pnl(5.0)
+        assert rm._daily_pnl == pytest.approx(15.0)
+
+    def test_negative_pnl_accumulates(self):
+        rm = _rm()
+        rm.record_pnl(-20.0)
+        rm.record_pnl(-15.0)
+        assert rm._daily_pnl == pytest.approx(-35.0)
+
+    def test_mixed_pnl_nets_correctly(self):
+        rm = _rm()
+        rm.record_pnl(30.0)
+        rm.record_pnl(-10.0)
+        assert rm._daily_pnl == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# Daily reset
+# ---------------------------------------------------------------------------
+
+class TestDailyReset:
+    """_reset_if_new_day() clears PnL when the UTC date has changed."""
+
+    def test_reset_clears_daily_pnl(self):
+        from datetime import date
+        rm = _rm()
+        rm._daily_pnl = -40.0
+        # Simulate a new day by backdating _trade_day
+        rm._trade_day = date(2000, 1, 1)
+        rm._reset_if_new_day()
+        assert rm._daily_pnl == 0.0
+
+    def test_reset_updates_trade_day(self):
+        from datetime import date, datetime, timezone
+        rm = _rm()
+        rm._trade_day = date(2000, 1, 1)
+        rm._reset_if_new_day()
+        assert rm._trade_day == datetime.now(timezone.utc).date()
+
+    def test_no_reset_on_same_day(self):
+        rm = _rm()
+        rm._daily_pnl = -20.0
+        # _trade_day is already today, so no reset should happen
+        rm._reset_if_new_day()
+        assert rm._daily_pnl == pytest.approx(-20.0)
+
+    def test_allow_trade_triggers_reset_on_new_day(self):
+        from datetime import date
+        rm = _rm(daily_loss_limit_eur=50.0)
+        rm._daily_pnl = -51.0          # would normally block
+        rm._trade_day = date(2000, 1, 1)  # simulate yesterday
+        ok, _ = rm.allow_trade(capital=500.0, liquidity_contracts=100)
+        # After reset, PnL is 0 — trade should be allowed
+        assert ok is True


### PR DESCRIPTION
## What this PR does

Closes #42 (E1-1 — implement `src/risk/manager.py`)

Implements the `RiskManager` dataclass that gates every trade before execution. This is a required safety layer before any real capital is deployed.

## What changed

- **`src/risk/manager.py`** — new module with `RiskManager` dataclass:
  - 4 configurable limits: `daily_loss_limit_eur`, `max_open_positions`, `drawdown_stop_pct`, `min_market_liquidity`
  - In-memory state: `_daily_pnl`, `_open_positions`, `_trade_day`
  - Methods: `_reset_if_new_day()`, `record_pnl()`, `open_position()`, `close_position()`, `allow_trade()`
  - All limits default to values from `src/config.py` (env-var overrides); nothing hardcoded in manager
  - Daily PnL resets at midnight UTC; state not persisted across restarts (acceptable for paper-trading phase)

- **`src/config.py`** — adds the 5 RISK_* environment variables (`STARTING_CAPITAL_EUR`, `RISK_DAILY_LOSS_LIMIT_EUR`, `RISK_MAX_OPEN_POSITIONS`, `RISK_DRAWDOWN_STOP_PCT`, `RISK_MIN_LIQUIDITY`) that `manager.py` reads from.

- **`src/tests/test_risk.py`** — 30 unit tests covering:
  - Normal (allow) case: `allow_trade()` returns `(True, "")` when all limits are clear
  - Daily loss limit: blocks at and above limit, allows just below
  - Max open positions: blocks at and above limit, allows one below
  - Drawdown stop: blocks at exact threshold and beyond, allows just above threshold
  - Min market liquidity: blocks below minimum, allows at and above
  - `record_pnl()`: PnL accumulation (positive, negative, mixed)
  - Daily reset: clears PnL on new day, preserves PnL same day, `allow_trade()` triggers reset

## How to test

```bash
python -m pytest src/tests/test_risk.py -v   # 30 tests, all should pass
python -m pytest src/tests/ -v               # full suite — no regressions (85 tests)
```

Manual smoke test from the issue:

```python
from src.risk.manager import RiskManager

rm = RiskManager(daily_loss_limit_eur=50.0, starting_capital=500.0)

# Normal — should allow
ok, reason = rm.allow_trade(capital=500.0)
assert ok

# Daily loss hit
rm._daily_pnl = -51.0
ok, reason = rm.allow_trade(capital=449.0)
assert not ok and "daily loss" in reason
```